### PR TITLE
fixed print.summary Pr(>|z|) vs. Pr(>|t|) problem

### DIFF
--- a/R/summary.speedglm.R
+++ b/R/summary.speedglm.R
@@ -91,7 +91,7 @@ print.summary.speedglm <- function(x,digits = max(3, getOption("digits") - 3),..
       ".  "
     else "   "
   }
-  sig.1 <- sapply(as.numeric(as.character(x$coefficients$"Pr(>|t|)")), sig)
+  sig.1 <- sapply(as.numeric(as.character(x$coefficients[, ncol(x$coefficients)])), sig)
   est.1 <- cbind(format(x$coefficients, digits = digits), sig.1)
   colnames(est.1)[ncol(est.1)] <- ""
   print(est.1)


### PR DESCRIPTION
summary.speedglm produces an object whose last column is always a p-value, but sometimes it is named Pr(>|t|) and sometimes it is named Pr(>|z|).  This causes an error with cbind in print.summary.speedglm (line 94), which causes the print to fail.  I fixed it by telling it to use the last column of x$coefficients, x$coefficients[, ncol(x$coefficients)].
